### PR TITLE
feat: Add checkpoint command for project phase transitions

### DIFF
--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,0 +1,89 @@
+**Purpose**: Audit & reorganize project planning documents during phase transitions
+
+---
+
+@include shared/universal-constants.yml#Universal_Legend
+
+## Command Execution
+Execute: immediate. --plan→show plan first
+Legend: Generated based on symbols used in command
+Purpose: "Audit planning documents for phase transition in $ARGUMENTS"
+
+Audits completed work against planning documents, reorganizes plans by completion status, consolidates duplicates, and ensures clean state for upcoming phases.
+
+@include shared/flag-inheritance.yml#Universal_Always
+
+## Command-Specific Flags
+
+**Phase Definition**:
+- **--completed** "*phases 1-4*" → Define completed phases/milestones for audit
+- **--upcoming** "*phases 5+*" → Define upcoming phases requiring clean planning
+- **--sources** "*prs,docs,commits*" → Sources to analyze for completion status
+
+**Directory Structure**:
+- **--plans-dir** "*docs/plans*" → Directory containing planning documents  
+- **--done-dir** "*docs/plans/done*" → Directory for completed plans
+- **--worktree** "*checkpoint-audit*" → Worktree name for isolated audit work
+- **--branch** "*audit/phase-transition*" → Branch name for audit work
+
+Examples:
+- `--checkpoint --completed "phases 1-4" --upcoming "phases 5+"`
+- `--checkpoint --completed "sprint 1-3" --upcoming "sprint 4+" --plans-dir "docs/sprints"`
+- `--checkpoint --completed "milestones A-C" --upcoming "milestones D+" --plans-dir "planning" --done-dir "archive/completed" --branch "audit/milestone-cleanup"`
+
+## Execution Workflow
+
+**Phase 1: Environment Setup**
+- Creates isolated worktree for audit work
+- Syncs w/ remote main branch → switches to audit branch
+
+**Phase 2: Assessment**
+- Analyzes completed work from specified sources
+- Reviews planning documents in plans directory
+- Maps completed work to existing plans
+
+**Phase 3: Audit & Categorization**
+- Categorizes plans: completed | remaining | duplicate
+- Identifies gaps in planning for upcoming phases
+- Generates audit report w/ recommendations
+
+**Phase 4: Reorganization**
+- Moves completed plans→done directory
+- Consolidates duplicate plans
+- Updates remaining plans for clarity
+
+**Phase 5: Validation**
+- Ensures remaining plans ready for next phases
+- Verifies no critical planning gaps exist
+- Confirms clean state for continuation
+
+**Phase 6: Commit Strategy**
+- Frequent small commits w/ descriptive messages
+- Maintains audit trail of all changes
+- Prepares for merge back to main
+
+## Intelligence Features
+
+- **Smart Detection**: Auto-identifies completed work patterns
+- **Duplicate Analysis**: Semantic comparison of planning documents  
+- **Dependency Mapping**: Understands plan interdependencies
+- **Gap Analysis**: Identifies missing planning for upcoming phases
+
+## Output & Integration
+
+**Deliverables**:
+- Audit report w/ recommendations
+- Reorganized planning directory structure
+- Clean branch ready for merge
+- Summary of changes made
+
+**Safety & Integration**:
+- Creates isolated environment for audit work
+- Maintains audit trail of all changes
+- Requires explicit confirmation for destructive operations
+- Preserves original documents until audit completion
+- Works w/ existing project structures & git workflow
+
+@include shared/docs-patterns.yml#Standard_Notifications
+
+@include shared/universal-constants.yml#Standard_Messages_Templates

--- a/.claude/commands/index.md
+++ b/.claude/commands/index.md
@@ -3,14 +3,14 @@
 @include shared/universal-constants.yml#Universal_Legend
 
 ## Ultra-Compressed Reference
-Commands: `/cmd --flags` | 23 total | Universal flags available
+Commands: `/cmd --flags` | 24 total | Universal flags available
 
 @include shared/flag-inheritance.yml#Universal_Always
 
 ## Command Categories
 **Analysis**: `/analyze` `/scan` `/explain` `/review`
 **Build**: `/build` `/deploy` `/migrate` 
-**Manage**: `/task` `/load` `/cleanup`
+**Manage**: `/task` `/load` `/cleanup` `/checkpoint`
 **Dev**: `/test` `/troubleshoot` `/improve` `/make-make`
 **Utils**: `/design` `/document` `/estimate` `/dev-setup` `/git` `/yolo-merge` `/abort` `/pull-main` `/spawn`
 
@@ -19,7 +19,7 @@ Commands: `/cmd --flags` | 23 total | Universal flags available
 **Analysis**: `/analyze` --code|arch | `/review` --files|commit|pr | `/troubleshoot` --fix|prod | `/improve` --perf|quality | `/explain` --depth
 **Ops**: `/deploy` --env|rollback | `/migrate` --dry-run | `/scan` --security | `/estimate` --detailed | `/cleanup` --all | `/git` --commit|sync | `/yolo-merge` --squash|force | `/abort` --save-work|force | `/pull-main` --force|backup
 **Design**: `/design` --api|ddd | `/document` --api|user | `/spawn` --task
-**Manage**: `/task` :create|:status|:resume | `/load` --context
+**Manage**: `/task` :create|:status|:resume | `/load` --context | `/checkpoint` --completed|upcoming
 ## Workflow Patterns
 **Setup**: `/load` → `/dev-setup --install` → `/build --init` → `/test`
 **Feature**: `/analyze` → `/design --api` → `/build --tdd` → `/test --e2e` → `/deploy`

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -457,7 +457,7 @@ Professional system design with specifications.
 /design --microservices --event-driven   # Microservices design
 ```
 
-### 🔄 Workflow Commands (4)
+### 🔄 Workflow Commands (5)
 
 #### `/spawn` - Specialized Agents
 Spawn focused agents for parallel tasks.
@@ -536,6 +536,25 @@ Complex feature management across sessions with automatic breakdown and recovery
 /task:complete oauth-task-id                             # Complete with summary
 ```
 
+#### `/checkpoint` - Project Phase Transition
+Audit and reorganize project planning documents during phase transitions.
+
+**Command-Specific Flags:**
+- `--completed` - Define completed phases/milestones for audit
+- `--upcoming` - Define upcoming phases requiring clean planning
+- `--sources` - Sources to analyze for completion (prs,docs,commits)
+- `--plans-dir` - Directory containing planning documents
+- `--done-dir` - Directory for completed plans
+- `--worktree` - Worktree name for isolated audit work
+- `--branch` - Branch name for audit work
+
+**Examples:**
+```bash
+/checkpoint --completed "phases 1-4" --upcoming "phases 5+"        # Basic transition
+/checkpoint --completed "sprint 1-3" --upcoming "sprint 4+" --plans-dir "docs/sprints"  # Sprint checkpoint
+/checkpoint --completed "milestones A-C" --upcoming "milestones D+" --plans-dir "planning" --done-dir "archive/completed"  # Custom setup
+```
+
 ---
 
 ## Flag Combinations & Best Practices
@@ -612,4 +631,4 @@ Complex feature management across sessions with automatic breakdown and recovery
 
 ---
 
-**SuperClaude v2.0.1** - 19 professional commands | 9 cognitive personas | Advanced MCP integration | Evidence-based methodology
+**SuperClaude v2.0.1** - 20 professional commands | 9 cognitive personas | Advanced MCP integration | Evidence-based methodology


### PR DESCRIPTION
## Summary
- Implement `/checkpoint` command for auditing and reorganizing planning documents during phase transitions
- Support configurable phase definitions with `--completed` and `--upcoming` flags
- Isolated worktree workflow with comprehensive audit trail
- Smart detection of completed work from PRs, docs, and commits

## Test plan
- [x] Command file created following SuperClaude patterns
- [x] Documentation updated in index.md and COMMANDS.md
- [x] Command count incremented (24 total)
- [x] Added to Manage category and workflow flags
- [ ] Manual testing of command functionality
- [ ] Integration testing with existing workflow

🤖 Generated with [Claude Code](https://claude.ai/code)